### PR TITLE
refactor: replace setup.sh with /configure command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,14 @@ agent-workflow/
 │   │   ├── reviewer-tests/       # Test quality and coverage
 │   │   ├── reviewer-architecture/# Duplication, patterns
 │   │   └── reviewer-plan/        # Plan validation
-│   └── commands/                 # Slash commands (/plan, /work)
+│   └── commands/                 # Slash commands (/plan, /work, /configure)
 ├── .github/
 │   ├── workflows/                # GitHub Actions (review, orchestrator, guardrails)
 │   ├── agent-workflow/           # Workflow configuration
 │   └── ISSUE_TEMPLATE/           # Issue templates for tasks and review findings
 ├── templates/
 │   └── CLAUDE.md                 # Starter CLAUDE.md for target projects
-├── install.sh                    # curl-able installer
-├── setup.sh                      # Branch protection setup via gh api
+├── install.sh                    # curl-able installer (copies files only)
 ├── docs/
 │   └── design.md                 # Full design document
 └── README.md
@@ -38,7 +37,7 @@ agent-workflow/
 - **Hierarchical branching** — branch structure mirrors issue structure
 - **Leaf tasks commit to parent branch** (no sub-branch per leaf)
 - **PR approval as universal override** for guardrail checks
-- **Two commands only:** `/plan` and `/work`
+- **Three commands:** `/plan`, `/work`, and `/configure`
 
 ## Design Reference
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ The solution isn't better instructions — it's **structural enforcement**. A de
 ## Quick Start
 
 ```bash
-# Install into your project
+# Install workflow files into your project
 curl -fsSL https://raw.githubusercontent.com/jdelfino/agent-workflow/main/install.sh | bash
+```
 
-# Configure branch protection and required checks
-./setup.sh
+Then in a Claude Code terminal:
+```
+# Interactive setup: branch protection, git hooks, Claude auth, guardrails
+/configure
 ```
 
 ## How It Works
@@ -111,7 +114,7 @@ guardrails:
 - GitHub repository
 - [Claude Code](https://claude.ai/code) CLI installed
 - `gh` CLI authenticated with repo access
-- `ANTHROPIC_API_KEY` as a GitHub Secret (for automated reviews)
+- Run `/configure` to set up Claude authentication and branch protection
 
 ## License
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -140,7 +140,7 @@ This is the skeleton. Non-negotiable, deterministic, platform-enforced.
 - **Branch protection on main.** No direct pushes. PRs required. Status checks required. No exceptions.
 - **Required status checks.** Tests, linting, the orchestrator check (see Layer 3), and all enabled guardrail checks must pass before merge. Guardrail checks use native GitHub check run conclusions (`success`, `neutral`, `action_required`) to report results — no custom schema needed.
 - **Auto-merge enabled.** When all checks pass and required reviews (if any) are satisfied, the PR merges automatically. The default path is fully automated.
-- **Setup script.** A `setup.sh` that configures all of the above via `gh api` commands. Run once, enforcement is in place.
+- **`/configure` command.** An interactive Claude Code command that sets up all of the above: branch protection via `gh api`, git hooks (Layer 0), Claude authentication (`/install-github-app`), guardrail configuration, and CLAUDE.md population. Run once from a Claude Code terminal after installing the workflow files.
 
 ### Layer 2: Intelligence (Skills)
 
@@ -469,15 +469,15 @@ agent-workflow-template/
 │   │   └── reviewer-architecture.md   # Architecture review skill
 │   └── commands/
 │       ├── plan.md                    # /plan command
-│       └── work.md                    # /work command
+│       ├── work.md                    # /work command
+│       └── configure.md              # /configure command (interactive setup)
 ├── CLAUDE.md                          # Starter project context (fill in per project)
-├── setup.sh                           # Configures branch protection via gh api
 └── README.md
 ```
 
 ## What Ships in v1
 
-- Setup script for branch protection and required status checks
+- `/configure` command for interactive setup: branch protection, git hooks, Claude auth, guardrails, CLAUDE.md
 - Orchestrator status check Action (the brain — blocker evaluation, re-review assessment)
 - PR review workflow invoking three reviewer skills via `claude -p`
 - Guardrail checks as independent workflow files using native GitHub check runs (scope, test ratio, dependency changes, API surface, commit messages)


### PR DESCRIPTION
## Summary
- Replace `setup.sh` with `/configure` — an interactive Claude Code command for project setup
- Update design.md, README.md, and CLAUDE.md to reflect the new flow
- Installation becomes: `curl ... | bash` (copy files) then `/configure` (interactive setup)

`/configure` handles: branch protection, git hooks, Claude auth, guardrails, CLAUDE.md population.

Related: closes #24, expands #35, updates #4

## Test plan
- [ ] Verify design.md references are consistent
- [ ] Verify README quick start flow makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)