### PR TITLE
feat: adopt worktree-isolation pattern, add test-runner, harden hooks

### DIFF
--- a/.claude/hooks/block-branch-switch.sh
+++ b/.claude/hooks/block-branch-switch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Hook: Block git checkout/switch to feature branches in main workspace.
+# Allows: checkout -b (create), checkout -- (restore), checkout main
+# Allows: all checkouts inside worktrees (they're already isolated)
+
+# Allow everything inside a worktree
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+CURRENT_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$MAIN_REPO" ] && [ -n "$CURRENT_TOPLEVEL" ] && [ "$CURRENT_TOPLEVEL" != "$MAIN_REPO" ]; then
+  echo '{}'
+  exit 0
+fi
+
+cmd=$(jq -r '.tool_input.command')
+if echo "$cmd" | grep -qE '^git (checkout|switch)' \
+   && ! echo "$cmd" | grep -qE '^git checkout (-b |-- )' \
+   && ! echo "$cmd" | grep -qE '^git (checkout|switch) main$'; then
+  echo '{"decision":"block","reason":"BLOCKED: Do not switch branches in the main workspace. Use: git worktree add ../<name> <branch>. Read .claude/skills/coordinator/SKILL.md for the full worktree workflow."}'
+else
+  echo '{}'
+fi

--- a/.claude/hooks/block-hook-bypass.sh
+++ b/.claude/hooks/block-hook-bypass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Hook: Block commands that bypass git hooks (--no-verify, --no-gpg-sign, LEFTHOOK=0, etc.)
+cmd=$(jq -r '.tool_input.command')
+if echo "$cmd" | grep -qiE '(--no-verify|--no-gpg-sign|LEFTHOOK=0|LEFTHOOK_SKIP|HUSKY=0)'; then
+  echo '{"decision":"block","reason":"BLOCKED: Never bypass git hooks. If hooks fail, investigate the underlying cause — or ask the user."}'
+else
+  echo '{}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,21 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-branch-switch.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-hook-bypass.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -9,7 +9,7 @@ You are the single entry point for all implementation work. You triage incoming 
 
 **Model guidance:** The coordinator should run on Opus 4.6. Implementer subagents should run on Sonnet 4.6 (`model: "sonnet"`).
 
-**IMPORTANT:** The main branch is protected. All changes MUST go through a feature branch and PR. Direct commits to main are not allowed.
+**IMPORTANT:** The `main` branch is protected. All changes MUST go through a feature branch and PR. Direct commits to main are not allowed.
 
 ## Phase 1: Triage
 
@@ -18,42 +18,52 @@ You are the single entry point for all implementation work. You triage incoming 
 The input is either a beads ID or an ad-hoc description.
 
 **If beads ID:**
+
 ```bash
 bd show <id> --json
 ```
 
 If it's an epic, also fetch subtasks:
+
 ```bash
 bd list --parent <id> --json
 ```
 
 **If ad-hoc description (no beads ID):**
 Create a beads issue first:
+
 ```bash
 bd create "<description>" -t <task|bug|feature> -p 2 --json
 ```
+
+### 2. Check for Existing Branch
+
+If the issue is a fix for code on an existing feature branch (e.g., CI failure on an open PR, `discovered-from` dependency on an issue labeled `in-pr`, or the code to fix doesn't exist on `main`), use that branch as the base instead of `origin/main`. Commit directly to it — do not create a new branch or PR.
 
 ---
 
 ## Branch Mode
 
-All work uses branches and PRs. Uses worktrees and subagents.
+All work uses branches and PRs. Uses worktree isolation for subagents.
 
 ### 1. Setup
 
+**Always branch from `origin/main` unless explicitly directed otherwise by the prompt.** Fetch first to ensure it's up to date:
+
 ```bash
-# Create feature branch from main
 git fetch origin main
 git branch feature/<work-name> origin/main
-
-# Create worktree
-git worktree add ../<project>-<work-name> feature/<work-name>
-
-# CRITICAL: Install dependencies BEFORE spawning subagents
-cd ../<project>-<work-name>
-# Run your project's dependency install command here
-cd <back to main checkout>
 ```
+
+Then enter a worktree:
+
+```
+EnterWorktree(name: "<work-name>")
+```
+
+The coordinator works from its worktree for the rest of the session.
+
+If your project requires per-worktree dependency setup (symlinks, lockfile resolution, generated files), run that here. Document the steps in CLAUDE.md so they stay in sync with project changes.
 
 ### 2. Conflict Avoidance
 
@@ -82,46 +92,83 @@ bd dep add <later-task-id> <earlier-task-id> --json
 
 ### 3. Implement Tasks
 
-**Independent tasks CAN run in parallel. Dependent tasks MUST wait.**
+**Follow the dependency graph from beads.** Spawn all currently-unblocked tasks in parallel. When a task completes, check if any blocked tasks are now unblocked and spawn those.
 
 For each task:
 
 #### a. Claim
+
 ```bash
 bd update <task-id> --set-labels wip --json
 ```
 
 #### b. Spawn Implementer Subagent
 
-Use the Task tool with `subagent_type: "general-purpose"` and `model: "sonnet"`:
+Use the Agent tool with `isolation: "worktree"` and `model: "sonnet"`:
 
 ```
 ROLE: Implementer
 SKILL: Read and follow .claude/skills/implementer/SKILL.md
 
-WORKTREE: ../<project>-<work-name>
 TASK: <task-id>
 Read the task description: bd show <task-id> --json
-
-CONSTRAINTS:
-- Work ONLY in the worktree path above
-- Do NOT modify beads issues
-- Commit and push your work when implementer phases are complete
-- Phase 5 of the implementer skill produces a structured summary — that is your final output
 ```
 
 #### c. Handle Result
 
 The implementer's final output is a structured summary (Phase 5). Only read that summary — ignore intermediate tool output from the subagent.
 
-**On SUCCESS:**
+The agent result includes `worktree_path` and `branch` when changes were made.
+
+**On SUCCESS:** integrate into the feature branch (sequential — do NOT run in parallel with other integrations).
+
+Try fast-path rebase first (inline — no subagent):
+
+```bash
+cd <worktree_path>
+git rebase feature/<work-name> && \
+  git branch -f feature/<work-name> HEAD && \
+  echo "REBASE: OK"
+```
+
+After successful rebase, clean up:
+
+```bash
+git worktree remove <worktree_path> --force 2>/dev/null
+git branch -D <branch> 2>/dev/null
+```
+
+If the rebase fails (conflict), abort and spawn the rebase subagent. Do NOT use `isolation: "worktree"` — the rebase agent enters the implementer's existing worktree:
+
+```bash
+git rebase --abort
+```
+
+```
+ROLE: Rebase Agent (Conflict Resolution)
+SKILL: Read and follow .claude/skills/rebase/SKILL.md
+
+SOURCE: <branch>
+TARGET: feature/<work-name>
+WORKTREE: <worktree_path>
+CLEANUP: true
+BEADS_IDS: <task-id>
+```
+
+**After successful integration** (either path):
+
 ```bash
 bd close <task-id> --reason "Implemented" --json
 ```
-Check the "Concerns" section — file follow-up issues if needed.
 
-**On FAILURE:**
-- If recoverable: fix directly or spawn new subagent with clarification
+Triage the "Concerns" section:
+- **Bugs or broken behavior introduced by this task** — must be fixed before the PR ships. File an issue, spawn an implementer, and fix it on the feature branch.
+- **Low-priority, non-behavioral issues** (naming nits, future optimization ideas, minor code smells) — file as follow-up issues.
+- **Anything ambiguous** — ask the user whether to fix now or defer.
+
+**On rebase subagent FAILURE:**
+
+- Spawn a new implementer in a fresh worktree to resolve the conflict
 - If blocked: note the blocker, move to next task
 - Do NOT close the task
 
@@ -129,34 +176,37 @@ Check the "Concerns" section — file follow-up issues if needed.
 
 Reviews are **optional** for small, isolated changes (single-file fixes, typo corrections, config tweaks). For anything of any complexity — multi-file changes, new features, behavioral changes, refactors — reviews are **required**.
 
-After all tasks are complete, run 3 specialized reviews **in parallel** using the Task tool:
+After all tasks are merged into the feature branch, run 3 specialized reviews **in parallel**. Each reviewer enters the coordinator's worktree (do NOT use `isolation: "worktree"`):
 
 **Correctness Reviewer:**
+
 ```
 ROLE: Correctness Reviewer
 SKILL: Read and follow .claude/skills/reviewer-correctness/SKILL.md
 
-WORKTREE: ../<project>-<work-name>
+WORKTREE: <coordinator's worktree path>
 BASE: origin/main
 SUMMARY: <what this PR implements>
 ```
 
 **Test Quality Reviewer:**
+
 ```
 ROLE: Test Quality Reviewer
 SKILL: Read and follow .claude/skills/reviewer-tests/SKILL.md
 
-WORKTREE: ../<project>-<work-name>
+WORKTREE: <coordinator's worktree path>
 BASE: origin/main
 SUMMARY: <what this PR implements>
 ```
 
 **Architecture Reviewer:**
+
 ```
 ROLE: Architecture Reviewer
 SKILL: Read and follow .claude/skills/reviewer-architecture/SKILL.md
 
-WORKTREE: ../<project>-<work-name>
+WORKTREE: <coordinator's worktree path>
 BASE: origin/main
 SUMMARY: <what this PR implements>
 REFERENCE DIRS: <key directories in the existing codebase to compare against>
@@ -167,24 +217,37 @@ REFERENCE DIRS: <key directories in the existing codebase to compare against>
 - **Trivial issues** (typos, minor naming): fix directly, commit
 - **Non-trivial issues** (bugs, missing tests, duplication): file a beads issue, spawn implementer, close when fixed
 
-After all issues resolved, re-run quality gates per the **Quality Gates** table in CLAUDE.md.
+After all issues resolved, run a test-runner sub-agent for **epic-level acceptance tests** (if the epic defined them) using `model: "haiku"`. Pull the test commands from the **Quality Gates** table in CLAUDE.md:
 
-### 5. Create PR and Hand Off
+```
+ROLE: Test Runner
+SKILL: Read and follow .claude/skills/test-runner/SKILL.md
 
-Run quality gates per the **Quality Gates** table in CLAUDE.md in the worktree before creating the PR.
+WORKTREE: <coordinator's worktree path>
+COMMANDS:
+- <acceptance test commands if the epic defined them>
+```
 
-**Do NOT create PR if any checks fail.** Fix locally first.
+**Skip the test-runner** if the epic has no acceptance tests. **Do NOT create PR if the test-runner reports FAIL.** Fix locally first (spawn implementer if non-trivial).
+
+### 5. Create PR, Monitor CI, and Hand Off
+
+Run quality gates per the **Quality Gates** table in CLAUDE.md before creating the PR. Delegate to a test-runner sub-agent so verbose output doesn't pollute the coordinator's context.
+
+**Do NOT create PR if any gate fails.** Fix locally first.
+
+**PR description guidelines:**
+
+- The summary should explain _why_ the change exists, not restate the diff. Reviewers can read the code.
+- Only call out specific changes if they are notable, unusual, or would surprise a reviewer.
+- Add additional sections (e.g., "Manual steps required") only when relevant.
 
 ```bash
-cd ../<project>-<work-name>
 git push -u origin feature/<work-name>
 
 gh pr create --title "<type>: <title>" --body "$(cat <<'EOF'
 ## Summary
-<1-3 bullet points>
-
-## Changes
-<list of significant changes>
+<1-3 bullet points explaining *why* this change exists>
 
 ## Test plan
 - [ ] Tests pass
@@ -197,20 +260,38 @@ EOF
 )"
 ```
 
-**After creating the PR:**
+**After creating the PR, monitor CI:**
+
+```bash
+gh pr checks <number> --watch
+```
+
+**If CI fails:**
+
+1. Fetch failure logs:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+2. **Trivial fix** (single-line, obvious test typo): fix inline, commit, push.
+3. **Non-trivial fix**: spawn an implementer in the coordinator's worktree to fix the failures, then push:
+   ```bash
+   git push
+   ```
+4. Re-run `gh pr checks <number> --watch` and repeat until CI passes.
+
+**After CI passes:**
 
 1. If user indicated review needed (e.g., "review this", "flag for review", or high-risk changes like auth/infra/migrations):
    ```bash
    gh pr edit <number> --add-label "needs-human-review"
    ```
-   This blocks merge until a human approves the PR on GitHub (requires the human-review-gate workflow — see `scripts/setup-github-app.sh`).
 2. Label beads issues as `in-pr`:
    ```bash
    bd update <id> --set-labels in-pr --json
    ```
-3. Report: "PR #X opened. `/merge` will handle CI and merging."
+3. Report: "PR #X opened. CI passing. `/merge` will handle merging."
 
-**Do NOT** watch CI, merge, or wait for approval. The `/merge` agent handles all of that.
+**Do NOT** merge. The `/merge` agent handles all merging.
 
 **Do NOT** clean up worktrees or branches. The `/merge` agent does this after successful merge, since worktrees may be needed for rebases.
 
@@ -219,12 +300,18 @@ EOF
 ## Anti-Patterns
 
 - Committing directly to main (branch is protected — all changes require a PR)
+- Creating a new branch/PR for a fix that belongs on an existing feature branch
 - Starting dependent task before blocker is closed
-- Parallelizing tasks that touch same files
+- Parallelizing tasks that touch the same files (use Conflict Avoidance section above)
+- Running task integrations in parallel (must be sequential for linear history)
 - Creating PR before running specialized reviews
 - Creating PR with failing tests
-- Merging PRs (that's `/merge`'s job)
-- Watching CI (that's `/merge`'s job)
-- Cleaning up worktrees before merge (that's `/merge`'s job)
-- Running dependency install concurrently in multiple worktrees
+- Shipping known bugs as follow-up issues — bugs introduced by the current work must be fixed before the PR ships
+- Spawning a rebase subagent when fast-path succeeds
 - Fixing non-trivial review issues inline — file issues and spawn implementers instead
+- Running quality gates directly in coordinator context — always delegate to test-runner sub-agents
+- Merging PRs (that's `/merge`'s job)
+- Handing off to `/merge` before CI passes — coordinator owns CI failures and must fix them
+- Cleaning up worktrees before merge (that's `/merge`'s job)
+- Manually creating worktrees with `git worktree add` — use `EnterWorktree` or `isolation: "worktree"`
+- Using `isolation: "worktree"` for rebase/reviewer/test-runner agents — they enter existing worktrees

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -7,7 +7,7 @@ description: Pure development workflow with test-first development and coverage 
 
 Follow these phases **in strict order**. Do not skip phases. Do not proceed until the current phase's gate is satisfied.
 
-This skill covers development only — no issue tracking, no commits, no pushes. The coordinator handles those.
+This skill covers development only — no issue tracking, no pushes. The coordinator handles those.
 
 ## Principles
 
@@ -16,10 +16,15 @@ This skill covers development only — no issue tracking, no commits, no pushes.
 - No type casts that bypass the type system.
 - No optional chaining on required properties.
 - **Every production code change requires tests.** No exceptions for migrations, refactors, copy-paste, or "just wiring things up." If you wrote or modified production code, you must write tests for it. Never defer tests to a follow-up issue.
+- **Test cases from the issue are your spec.** When the planner has defined concrete test cases on the task, implement those first, then add high-value coverage for gaps.
+- **Delegate quality-gate runs to a test-runner sub-agent.** Verbose test output consumes your context window — see Phase 3.
+- **If your project enforces lint/typecheck via git hooks** (e.g., lefthook, husky), do not re-run those gates manually. Focus on tests in Phase 3 and let the hooks do their job at commit/push time.
 
 ## Phase 1: Write Failing Tests
 
 Write tests for the behavior you are about to change or add. Do this **before** touching any production code.
+
+If the task issue lists planned test cases, implement those first — they are the acceptance criteria. Then add additional high-value tests for gaps you identify (error paths, edge cases).
 
 **This phase is NOT optional.** Common excuses that do NOT exempt you from writing tests:
 - "It's just a migration" — migrated code has new integration points that need testing
@@ -29,7 +34,9 @@ Write tests for the behavior you are about to change or add. Do this **before** 
 
 1. Read the relevant production code to understand current behavior
 2. Write new test cases that describe the desired behavior after your change
-3. Run the tests using the appropriate test command (see **Quality Gates** in CLAUDE.md)
+3. Verify the new tests fail by delegating to a test-runner sub-agent (see Phase 3)
+
+**Test documentation:** Planned and critical tests (integration, e2e, non-obvious unit tests) should include a docstring answering: what contract is verified, why it matters, what breaks if violated. Tests with descriptive names in table-driven style are often self-documenting — use judgment.
 
 **Gate:** Your new tests **fail** (or, for pure deletions/removals, you can write tests asserting the old behavior is gone — these will pass after implementation). If your new tests already pass, they are not testing anything new. Rewrite them.
 
@@ -39,9 +46,20 @@ Make the production code changes. Keep changes minimal and focused on the task.
 
 ## Phase 3: Verify
 
-Run quality gates matching the code you changed. See the **Quality Gates** table in CLAUDE.md for all targets.
+**Delegate quality-gate runs to a test-runner sub-agent** to preserve your context window. Do NOT run these commands directly with the Bash tool — test output is verbose and wastes context you need for later phases. Use the Task tool with `subagent_type: "Bash"` and `model: "haiku"`:
 
-**Gate:** All quality gate commands pass with zero errors. If any fails, fix the issues before proceeding.
+```
+ROLE: Test Runner
+SKILL: Read and follow .claude/skills/test-runner/SKILL.md
+
+WORKTREE: <worktree-path>
+COMMANDS:
+- <test commands from the Quality Gates table in CLAUDE.md matching changed code>
+```
+
+**Only run gates not already enforced by git hooks.** If your project's pre-commit/pre-push hooks already run lint/typecheck/unit-test, do not duplicate them here — your gate runs should focus on what's *not* in the hooks (typically integration and e2e tests).
+
+**Gate:** Sub-agent reports PASS. If FAIL, read the error summary, fix the issue, and re-delegate. Only run quality gates directly in your own context if you need to debug a failure interactively.
 
 ## Phase 4: Test Coverage Review
 
@@ -77,7 +95,7 @@ If integration tests are needed, write them.
 
 ### Step 4: Fill gaps
 
-Write any missing tests identified above. Then re-run quality gates.
+Write any missing tests identified above. Then re-run quality gates via the test-runner sub-agent.
 
 **Gate:** All tests pass, including your new coverage additions. If you identified no gaps in Steps 2-3, document your reasoning (e.g., "Changes were purely deletions; added regression tests in Phase 1 confirming removed elements no longer render").
 

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -45,23 +45,41 @@ This is collaborative. Do NOT silently make decisions — discuss with the user.
 4. Point out risks and tradeoffs proactively — don't wait to be asked
 5. Iterate until you and the user agree on the approach
 
-### Phase 3 — File Issues
+### Phase 3 — Present Acceptance Tests for Approval
+
+Before filing any issues, present all planned test cases to the user for explicit approval. Tests are the contract — they define what "done" means, and the user must agree.
+
+1. For each planned subtask, list its **task-level test cases** (scenario name, setup, assertions, what it catches)
+2. If the epic warrants acceptance tests, list those too
+3. If any task requires **modifying existing tests**, call these out separately and explicitly — which test file, which test case, what will change and why. Existing tests are human-approved contracts; changes need justification.
+4. Use AskUserQuestion to get explicit approval. The user may:
+   - Approve as-is
+   - Request changes (add/remove/modify test cases)
+   - Ask questions about coverage gaps
+5. Iterate until the user approves the test plan
+
+**Do NOT proceed to filing issues until tests are approved.** The test cases become the spec — changing them after filing means rewriting issues.
+
+### Phase 4 — File Issues
 
 Present the agreed approach as a concise summary and use AskUserQuestion to confirm before filing. **Do NOT use EnterPlanMode or ExitPlanMode** — those trigger Claude Code's built-in plan execution behavior.
 
 After the user approves:
 
 1. Create the epic if one doesn't exist:
+
    ```bash
    bd create "Epic title" -t epic -p <priority> --json
    ```
 
 2. Create subtasks with proper dependencies:
+
    ```bash
    bd create "Subtask title" -t task --parent <epic-id> --json
    ```
 
 3. Add dependencies between tasks:
+
    ```bash
    bd dep add <blocked-task> <blocker-task> --json
    ```
@@ -69,14 +87,63 @@ After the user approves:
 4. **Set dependencies to model execution order.** Tasks with no dependency relationship are implicitly parallel — the coordinator spawns all unblocked tasks concurrently. Use `bd dep add` only for true data/ordering dependencies (shared types, migrations before code, etc.). Don't over-constrain — occasional file overlap between parallel tasks is fine; the coordinator handles conflicts optimistically.
 
 **Each subtask MUST be self-contained** (per AGENTS.md rules):
+
 - **Summary**: What and why in 1-2 sentences
 - **Files to modify**: Exact paths (with line numbers if relevant)
 - **Files to read for context**: Paths the implementer will need to understand before coding
-- **Testing notes**: What test coverage to add. Call out integration tests explicitly when changes affect persistence, API routes, auth, or cross-layer data flow.
+- **Test cases**: Concrete acceptance tests for the task (see below)
+- **Existing test modifications**: If the task requires changing existing tests, list each modification explicitly — which test file, which test case, what changes and why. Implementers are NOT allowed to modify existing tests without this authorization.
 - **Implementation steps**: Numbered, specific actions
 - **Example**: Show before → after transformation when applicable
 
 A future implementer session must understand the task completely from its description alone — no external context.
+
+### Test Cases — Two Levels
+
+#### Task-Level Test Cases
+
+Each subtask includes a **Test Cases** section with concrete, named scenarios specifying type (unit/integration/e2e), setup, assertions, and what bug it catches. Be prescriptive — pseudo-code or detailed steps, not vague one-liners. The user reviews and approves test cases as part of plan approval.
+
+Pull test types from the **Quality Gates** table in CLAUDE.md. Prefer integration tests where the change crosses real boundaries (persistence, API routes, auth, cross-layer data flow); unit tests are appropriate for pure logic.
+
+**Examples:**
+
+```markdown
+## Test Cases
+
+1. (unit) myStore.addItem appends to items list
+   - Setup: store with empty items
+   - Call addItem(mockItem)
+   - Assert: items array contains mockItem
+   - Catches: reducer not updating state correctly
+
+2. (integration) GET /api/items returns user's items only
+   - Seed: two users, each with two items
+   - HTTP GET as user A
+   - Assert: response contains exactly user A's two items
+   - Catches: handler not propagating auth context to query
+```
+
+#### Epic-Level Acceptance Tests
+
+Define acceptance tests on the **epic issue itself** — the "done" criteria for the whole feature. Create an explicit subtask to implement them (with dependencies on implementation subtasks), duplicating the test definitions into it for self-containment. Skip for small epics where task-level tests suffice.
+
+**Example (on the epic issue):**
+
+```markdown
+## Acceptance Tests
+
+1. (e2e) Logged-in user sees their items list
+   - Log in as a user with items seeded
+   - Navigate to the items page
+   - Assert: each seeded item visible; empty-state hidden
+   - Catches: page not reading from correct store slice or API path
+
+2. (integration) Item ownership boundary enforced server-side
+   - As user A, request /api/items/<user-B-item-id>
+   - Assert: 403 or 404 (not 200)
+   - Catches: missing auth check on item-detail route
+```
 
 ### Task Sizing
 
@@ -84,12 +151,12 @@ Each subtask must fit within a single implementer context window without compact
 
 - **≤5 production files modified** per task
 - **≤10 files read for context** (including the files to modify, test files, shared types, referenced modules)
-- Prefer narrow vertical slices (one endpoint end-to-end) over horizontal layers (all endpoints at once)
+- Prefer narrow vertical slices (one feature end-to-end) over horizontal layers (all routes at once)
 - When in doubt, split. Two small tasks are better than one that causes compaction.
 
 If "Files to read for context" exceeds ~10 entries, the task is probably too large — consider splitting it. But if splitting would create awkward boundaries or tightly coupled tasks, it's better to leave a large task whole.
 
-### Phase 4 — Plan Review
+### Phase 5 — Plan Review
 
 After issues are filed, spawn a plan reviewer:
 
@@ -103,6 +170,7 @@ EPIC: <epic-id>
 The reviewer checks the filed issues against the codebase for architectural issues, duplication risks, missing tasks, and dependency correctness.
 
 **Handle reviewer feedback:**
+
 - Present findings to the user
 - Iterate: update, create, or close issues as needed
 - Re-run reviewer if significant changes were made
@@ -111,7 +179,7 @@ The reviewer checks the filed issues against the codebase for architectural issu
 
 ## Your Constraints
 
-- **MAY** use full beads access (create, update, close issues) — but only in Phases 3-4
+- **MAY** use full beads access (create, update, close issues) — but only in Phases 4-5
 - **NEVER** write code or create worktrees
 - **NEVER** skip the discussion phase — always get user input on key decisions
 - **ALWAYS** explore the codebase before proposing an approach
@@ -122,7 +190,7 @@ The reviewer checks the filed issues against the codebase for architectural issu
 - ❌ Write implementation code
 - ❌ Create worktrees or branches
 - ❌ Make architecture decisions without discussing with the user
-- ❌ File issues before the user approves the plan
+- ❌ File issues before the user approves the plan and test cases
 - ❌ Skip codebase exploration (guessing at patterns leads to bad plans)
 - ❌ Create vague subtasks ("implement the feature") — be specific
 - ❌ Use EnterPlanMode/ExitPlanMode (triggers unwanted auto-implementation)

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -19,6 +19,14 @@ You will receive:
 
 ## Execution
 
+### 0. Enter Worktree
+
+```
+EnterWorktree(path: <WORKTREE>)
+```
+
+All subsequent steps run from inside the worktree.
+
 ### 1. Gather intent
 
 Before touching git, understand what each side was trying to accomplish.

--- a/.claude/skills/reviewer-architecture/SKILL.md
+++ b/.claude/skills/reviewer-architecture/SKILL.md
@@ -24,10 +24,15 @@ You review the full codebase — not just the diff — to catch duplication, pat
 
 ## Review Process
 
+### 0. Enter Worktree
+
+```
+EnterWorktree(path: <WORKTREE>)
+```
+
 ### 1. Understand What Changed
 
 ```bash
-cd <worktree-path>
 git diff <base-branch>...HEAD --stat
 ```
 

--- a/.claude/skills/reviewer-correctness/SKILL.md
+++ b/.claude/skills/reviewer-correctness/SKILL.md
@@ -23,17 +23,22 @@ You review the full branch diff for correctness issues. You read every changed l
 
 ## Review Process
 
+### 0. Enter Worktree
+
+```
+EnterWorktree(path: <WORKTREE>)
+```
+
 ### 1. Get the Full Diff
 
 ```bash
-cd <worktree-path>
 git diff <base-branch>...HEAD --stat
 git diff <base-branch>...HEAD
 ```
 
 ### 2. Run Quality Gates
 
-Run quality gates per the **Quality Gates** table in CLAUDE.md. If any fail, note the specific failures.
+Run quality gates per the **Quality Gates** table in CLAUDE.md, unless they're already enforced by your project's git hooks (e.g., lefthook, husky). If you do run them and any fail, note the specific failures.
 
 ### 3. Review Every Changed File
 
@@ -53,7 +58,7 @@ For each file in the diff, check:
 
 #### Security
 - Input validation at system boundaries
-- SQL injection, command injection, XSS
+- Injection risks appropriate to your stack (SQL, command, XSS, template, etc.)
 - Authentication/authorization gaps
 - Secrets in code or logs
 - Unsafe type assertions or casts

--- a/.claude/skills/reviewer-tests/SKILL.md
+++ b/.claude/skills/reviewer-tests/SKILL.md
@@ -23,23 +23,49 @@ You evaluate whether the tests in a PR are meaningful. High coverage with bad te
 
 ## Review Process
 
-### 1. Identify Changed Production and Test Files
+### 0. Enter Worktree
+
+```
+EnterWorktree(path: <WORKTREE>)
+```
+
+### 1. Check Planned Test Cases
+
+If the PR is associated with beads issues (check the PR description for "Beads: ..." references), read the task descriptions to find **planned test cases**. These are the acceptance criteria — every planned test case must be implemented.
 
 ```bash
-cd <worktree-path>
+bd show <task-id> --json
+```
+
+### 2. Identify Changed Production and Test Files
+
+```bash
 git diff <base-branch>...HEAD --stat
 ```
 
-For every changed production file, find its corresponding test file. Flag production files with no tests.
+For every changed production file, find its corresponding test file. Flag production files with no tests (unless the change is genuinely test-free — pure config, copy, environment variables).
 
-### 2. Read Each Test File
+### 3. Read Each Test File
 
-For every test file, read it completely and check:
+**Review order matters.** Follow this sequence for every test file:
 
-#### Are Tests Meaningful?
-- Do tests verify actual behavior, or just that code doesn't crash?
-- Would a test catch a real regression if the implementation changed?
-- Are assertions checking the right things? (e.g., checking response body, not just status code)
+1. **Read docstrings first** (on planned/critical tests). Verify that docstrings answer: (a) what behavioral contract is being verified, (b) why it matters to correctness, and (c) what would break if violated. If a docstring only describes *what the code does* without explaining *why it matters*, flag it.
+2. **Spot-check assertions.** Verify assertions match the stated intent. You don't need to read every line — only dig deeper if something feels misaligned.
+3. **Go into implementation** only when a docstring is missing on a planned test, or the assertion pattern raises a concern.
+
+Note: Tests with descriptive table-driven names are often self-documenting. Docstrings are required on planned/critical tests (integration, e2e, non-obvious unit tests), not on every test.
+
+Then check:
+
+#### Planned Test Coverage
+- Are all test cases from the task issue implemented and matching the planned scenarios?
+- Flag any planned test case that is missing or substantially different from its specification
+
+#### Test Quality
+- Do tests verify actual behavior, or just that code doesn't crash? Would a regression be caught?
+- Are assertions checking the right things? (e.g., response body, not just status code)
+- Could a completely wrong implementation still pass? (sign of over-mocking or weak assertions)
+- Flag low-value tests: tautologies (`x != null`), `err == nil` without checking the result, no assertions, exhaustive unit tests for constructors/getters/wiring
 
 #### Mock vs Real Behavior
 - Do tests only exercise mocks, never testing real logic?
@@ -47,32 +73,34 @@ For every test file, read it completely and check:
 - Could a completely wrong implementation still pass these tests?
 
 #### Integration Test Coverage
-- Are there integration tests that exercise real dependencies (database, external services)?
-- Do integration tests cover the critical paths end-to-end? (e.g., HTTP request → handler → service → database → response)
-- Are database interactions tested against a real database (e.g., real database with migrations), not just mocked?
-- Do integration tests verify that queries and migrations work correctly together?
+- Are there integration tests that exercise real dependencies (database, external services) where the code crosses those boundaries?
+- Do integration tests cover critical paths end-to-end? (e.g., HTTP request → handler → service → store → response)
+- For database-touching code: are queries and migrations tested together against a real database, not just mocked?
+- For auth/permissions code: is the permission boundary verified against real fixtures, not just stubs?
 - Is there an appropriate balance of unit vs integration tests? (Unit tests for logic, integration tests for I/O boundaries)
 
-#### Edge Cases
-- Are error paths tested? (not just happy path)
-- Are boundary conditions covered? (empty input, max values, nil/null)
-- Are concurrent scenarios tested if the code is concurrent?
+#### Edge Cases & Skipped Tests
+- Are error paths, boundary conditions, and concurrent scenarios tested where relevant?
+- Flag `it.skip`/`t.Skip()`/equivalents that represent deferred work (not environment-gating) as non-trivial
 
-#### Test Names & Organization
-- Do test names describe the behavior being tested?
-- Are table-driven tests used where appropriate?
+### 4. Behavioral Coverage Gaps
 
-#### Meaningless Tests (flag these specifically)
-- Tests that assert `ctx != nil` or similar tautologies
-- Tests that only check `err == nil` without verifying the result
-- Tests that duplicate what the compiler already checks
-- Tests with no assertions at all
+Step back and think about the PR from the user/caller perspective. List the new or changed behaviors, then ask: **if this behavior regressed, would a test fail?**
 
-### 3. Assess Severity
+Flag untested behaviors — especially:
+- New capabilities with no test exercising the full path
+- Authorization rules with no denial test
+- Error cases that are handled but never triggered in tests
+- Side effects (events, emails, record updates) with no verification
+- Role/state-dependent behavior where only one variant is tested
 
-**Trivial**: misleading test name, minor missing edge case.
+Skip trivial behaviors and those already covered by planned tests.
 
-**Non-trivial**: production file with no tests, tests that provide false confidence (all mocks, no real logic tested), missing error path coverage, no integration tests for database/store code.
+### 5. Assess Severity
+
+**Trivial**: misleading test name, minor missing edge case, docstring that describes behavior but omits the "what breaks" clause.
+
+**Non-trivial**: planned test case not implemented, production file with no tests, tests that provide false confidence (all mocks, no real logic tested), missing error path coverage, no integration tests for database/store code, missing docstrings on planned/critical tests, new or changed behavior with no test that would catch a regression.
 
 ## Report Your Outcome
 
@@ -92,6 +120,12 @@ Issues:
 2. ...
 Untested production files:
 - <file path, or "None">
+Missing planned test cases:
+- <task-id: test case description, or "None">
 Missing integration tests:
 - <description of what needs integration testing, or "None">
+Docstring gaps:
+- <test-file:line — what is missing from the docstring, or "None">
+Untested behaviors:
+- <description of the behavior and why it matters, or "None">
 ```

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: test-runner
+description: Lightweight sub-agent that runs quality gates and returns a concise pass/fail result. Used by implementer and coordinator to preserve context.
+model: haiku
+---
+
+# Test Runner
+
+You are a test runner sub-agent. Your job is to run quality gate commands and return a concise result so the calling agent's context is not polluted with verbose test output.
+
+## Input
+
+You will receive:
+- **WORKTREE**: the path to run commands in
+- **Commands**: one or more quality gate commands to run sequentially
+
+## Execution
+
+1. Enter the worktree:
+   ```
+   EnterWorktree(path: <WORKTREE>)
+   ```
+2. Run each command sequentially. Stop at the first failure.
+
+## Output Protocol
+
+**ALWAYS** respond with exactly this format and nothing else:
+
+### On success (all commands pass):
+
+```
+RESULT: PASS
+Commands run:
+- <command 1>
+- <command 2>
+```
+
+### On failure:
+
+```
+RESULT: FAIL
+Failed command: <the command that failed>
+Exit code: <exit code>
+
+Error summary:
+<extract ONLY the meaningful failure information — assertion errors, compiler errors,
+lint violations, type errors. Skip passing tests, progress bars, and boilerplate.
+Max 50 lines.>
+```
+
+## Failure Summarization
+
+Test output is noisy. Extract the signal:
+
+- **Test failures**: the failing test name, expected vs. actual values, assertion message
+- **Compiler errors**: file, line, error message
+- **Lint errors**: file, line, rule, message
+- **Type errors**: file, line, expected vs. actual type
+
+Skip everything else — passing test counts, timing, coverage percentages, blank lines, stack frames from test infrastructure (not user code).


### PR DESCRIPTION
## Summary
- Coordinator uses `EnterWorktree` + `isolation: "worktree"` for subagent spawning. Reviewers and test-runner enter the coordinator's existing worktree.
- Coordinator monitors CI after PR creation and fixes failures before handing off to `/merge`.
- New `test-runner` skill — lightweight haiku sub-agent for running quality gates without polluting the caller's context.
- Tighter hook coverage on pre-tool-use Bash commands.

## Changes
- `coordinator/SKILL.md`: worktree-isolation pattern + CI monitoring loop. Conflict-avoidance section and Quality-Gates-table delegation preserved.
- `implementer/SKILL.md`: delegate gate runs to `test-runner` sub-agent; acknowledge git-hook-enforced gates. Strong test mandate and Phase 4 Coverage Review preserved.
- `planner/SKILL.md`: add Phase 3 acceptance-test approval gate + "existing test modifications" authorization rule. Generic placeholder examples.
- `reviewers (correctness/architecture/tests)` + `rebase`: add Phase 0 `EnterWorktree`.
- `reviewer-tests`: add docstring/planned-test enforcement and a generalized integration-test-depth checklist.
- `test-runner/SKILL.md`: NEW skill.
- `hooks/`: add `block-branch-switch.sh` (prevent branch swaps in main checkout) and `block-hook-bypass.sh` (block `--no-verify`, `--no-gpg-sign`, `LEFTHOOK=0`, etc.).
- `settings.json`: register both pre-tool-use hooks.

## Test plan
- [ ] Verify each skill renders and phase numbering is consistent
- [ ] Try a sample `/work` cycle to exercise `EnterWorktree` + reviewer delegation
- [ ] Confirm hooks fire: `git checkout other-branch` in main checkout should block; `git commit --no-verify` should block

Generated with Claude Code