### PR TITLE
Lift worktree mechanics into hooks; block tool calls in stale worktrees

### DIFF
--- a/.claude/commands/bug.md
+++ b/.claude/commands/bug.md
@@ -35,4 +35,16 @@ Do NOT skip investigation to "ship faster," make speculative fixes without confi
    EOF
    ```
 
-4. **Fix it** — invoke `/work` on the new issue.
+4. **Fix it** — use the Skill tool to invoke `/work` on the new issue ID.
+
+## MANDATORY: Delegation to /work
+
+**You MUST invoke `/work <issue-id>` for the fix. Do NOT implement the fix yourself.**
+
+`/bug` is an investigation workflow, not an implementation workflow. Your job ends at filing a complete beads issue and handing it to `/work`. The `/work` skill (coordinator) handles branching, implementation, review, PR creation, and CI — skipping it means no branch, no PR, no review, and potentially pushing directly to main.
+
+**Never:**
+- Edit production code directly from `/bug`
+- Commit or push changes from `/bug`
+- Skip `/work` because "it's a small fix"
+- Create branches or PRs from `/bug`

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,20 +1,24 @@
 # Work Coordinator
 
-Coordinate work on **$ARGUMENTS** using the coordinator workflow.
+User request: $ARGUMENTS
 
-## 1. Parse Input
+**All work happens in a worktree under `.claude/worktrees/`.** The directory you're in may be irrelevant — re-evaluate from the request above.
 
-- **`bd-*`** (beads ID): `bd show $ARGUMENTS --json`. If epic: `bd list --parent $ARGUMENTS --json`
-- **`#<number>`** (GitHub issue): Fetch and convert to beads issue:
-  ```bash
-  gh issue view <number> --json title,body,labels,number
-  bd create "<title>" -d "GitHub: #<number> — <description>" -t <type> -p <priority> --json
-  ```
-  Map GitHub labels to beads types. Priority 1 for bugs, 2 for features/tasks.
-- **Other** (ad-hoc description): The coordinator will create a beads issue.
+Run `git worktree list`, then:
 
-## 2. Follow the coordinator skill instructions below
+1. Extending an in-flight change → enter its existing worktree.
+2. Stacking new work on an in-flight branch → new worktree from that branch.
+3. Otherwise → new worktree from `origin/main`.
 
----
+To create one (from the main repo root):
+
+```bash
+git fetch origin <base> --quiet
+git worktree add .claude/worktrees/<slug> -b feature/<slug> origin/<base>
+```
+
+If your project requires per-worktree setup (node_modules symlink, lockfile resolution, generated files), run that here.
+
+Then `EnterWorktree(path: .claude/worktrees/<slug>)`. If already in a worktree, `ExitWorktree(action: "keep")` first.
 
 @.claude/skills/coordinator/SKILL.md

--- a/.claude/hooks/ask-on-main-edit.sh
+++ b/.claude/hooks/ask-on-main-edit.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Hook: Require user approval for Edit/Write/NotebookEdit targeting files in
+# the main checkout. Worktrees under .claude/worktrees/ are silently allowed.
+#
+# Checks the file_path argument rather than cwd — an agent can be inside a
+# worktree but use an absolute path that points into the main repo, and that
+# is the most common failure mode.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+
+# No file_path — nothing to gate.
+[ -z "$FILE_PATH" ] && echo '{}' && exit 0
+
+ABS_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || true)
+[ -z "$MAIN_REPO" ] && echo '{}' && exit 0
+
+# Outside the repo entirely — allow.
+case "$ABS_PATH" in
+  "$MAIN_REPO"/*) ;;
+  *) echo '{}'; exit 0 ;;
+esac
+
+# Inside a worktree — allow.
+case "$ABS_PATH" in
+  "$MAIN_REPO"/.claude/worktrees/*) echo '{}'; exit 0 ;;
+esac
+
+# Edit targets the main checkout — ask the user.
+REASON="This edit targets the main checkout ($ABS_PATH). Any change going into the repo should be made on a feature branch in a worktree (see .claude/commands/work.md). Approve only if this is a local-testing edit that will not be committed."
+
+jq -n --arg reason "$REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "ask",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/.claude/hooks/block-stale-worktree.sh
+++ b/.claude/hooks/block-stale-worktree.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PreToolUse (matcher: *): block tool calls while the agent is in a worktree
+# it hasn't acknowledged yet. The marker is written by mark-stale-worktree.sh
+# at SessionStart. EnterWorktree and ExitWorktree clear the marker on the
+# way through so the agent has an exit even when everything else is blocked.
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+GIT_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$GIT_TOP" ] && { echo '{}'; exit 0; }
+
+MARKER="$GIT_TOP/.claude/.stale-worktree"
+
+# Escape hatches: either tool clears the marker so the next call passes through.
+if [ "$TOOL_NAME" = "ExitWorktree" ] || [ "$TOOL_NAME" = "EnterWorktree" ]; then
+  rm -f "$MARKER" 2>/dev/null || true
+  echo '{}'
+  exit 0
+fi
+
+# No marker — pass through.
+[ ! -e "$MARKER" ] && { echo '{}'; exit 0; }
+
+# Marker present, tool isn't an escape — block.
+REASON=$(cat <<EOF
+BLOCKED: this session started inside a worktree ($GIT_TOP) and has not acknowledged it. Continuing risks stale reads and wrong-branch edits.
+
+Before doing anything else, choose one:
+  - ExitWorktree(action: "keep") — leave the worktree, continue from the main checkout
+  - EnterWorktree(path: <other-worktree>) — switch to the worktree that matches the user's request
+
+If this is NOT a fresh session and another agent is legitimately working in this worktree, pause and check in with the user before proceeding.
+EOF
+)
+
+jq -n --arg reason "$REASON" '{decision: "block", reason: $reason}'

--- a/.claude/hooks/mark-stale-worktree.sh
+++ b/.claude/hooks/mark-stale-worktree.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SessionStart: if pwd is inside a worktree, drop a marker so the
+# block-stale-worktree PreToolUse hook can block tool calls until the agent
+# acknowledges the worktree via ExitWorktree or EnterWorktree.
+#
+# The marker lives in the worktree's working tree (.claude/.stale-worktree)
+# and is excluded by .gitignore so it doesn't leak into commits or new
+# worktree checkouts.
+
+set -euo pipefail
+
+GIT_COMMON=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || true)
+GIT_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+[ -z "$GIT_COMMON" ] && exit 0
+[ -z "$GIT_TOP" ] && exit 0
+
+# In a worktree iff working-tree root differs from the main repo root.
+if [ "$GIT_TOP" != "$GIT_COMMON" ]; then
+  mkdir -p "$GIT_TOP/.claude" 2>/dev/null || true
+  touch "$GIT_TOP/.claude/.stale-worktree" 2>/dev/null || true
+fi

--- a/.claude/hooks/set-repo-root.sh
+++ b/.claude/hooks/set-repo-root.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Hook: SessionStart + CwdChanged — keep REPO_ROOT pointing to the current repo/worktree root.
+# Other hooks can then resolve their scripts via "$REPO_ROOT/.claude/hooks/..."
+# regardless of which worktree or subdirectory the agent is currently in.
+
+set -euo pipefail
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+  if [ -n "$REPO_ROOT" ]; then
+    echo "export REPO_ROOT=$REPO_ROOT" >> "$CLAUDE_ENV_FILE"
+  fi
+fi

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Hook: WorktreeCreate — set up a worktree branched from the caller's HEAD.
+# Fires when an agent runs EnterWorktree(name: ...) or spawns a subagent with
+# isolation: "worktree". Stdout is consumed as the worktree path.
+#
+# Customize the post-create section for your project's per-worktree setup
+# (symlinking node_modules, fetching generated files, downloading deps, etc.).
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Resolve the main repo root (follows symlinks through worktrees)
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+[ -z "$MAIN_REPO" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+
+NAME=$(echo "$INPUT" | jq -r '.name // empty')
+[ -z "$NAME" ] && { echo ""; exit 0; }
+
+WORKTREE_PATH="$MAIN_REPO/.claude/worktrees/$NAME"
+
+# Branch from the caller's HEAD so subagent worktrees inherit the
+# coordinator's feature branch (rather than always branching from main).
+BASE_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+
+if [ ! -d "$WORKTREE_PATH" ]; then
+  git -C "$MAIN_REPO" worktree add "$WORKTREE_PATH" -b "worktree-$NAME" "$BASE_BRANCH" >/dev/null 2>&1 || true
+fi
+
+# Project-specific setup: customize the block below for your project.
+# Common patterns:
+#   ln -s "$MAIN_REPO/node_modules" "$WORKTREE_PATH/node_modules" 2>/dev/null || true
+#   (cd "$WORKTREE_PATH" && go mod download) >/dev/null 2>&1 || true
+#   cp "$MAIN_REPO/.env.local" "$WORKTREE_PATH/.env.local" 2>/dev/null || true
+
+echo "$WORKTREE_PATH"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,21 +15,67 @@
           {
             "type": "command",
             "command": "cat AGENTS.md"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/set-repo-root.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/mark-stale-worktree.sh"
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/set-repo-root.sh\""
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/worktree-create.sh\""
           }
         ]
       }
     ],
     "PreToolUse": [
       {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/block-stale-worktree.sh\""
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/block-branch-switch.sh"
+            "command": "bash \"$REPO_ROOT/.claude/hooks/block-branch-switch.sh\""
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/block-hook-bypass.sh"
+            "command": "bash \"$REPO_ROOT/.claude/hooks/block-hook-bypass.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/ask-on-main-edit.sh\""
           }
         ]
       }

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -15,9 +15,9 @@ You are the single entry point for all implementation work. You triage incoming 
 
 ### 1. Parse Input
 
-The input is either a beads ID or an ad-hoc description.
+The input is a beads ID, a GitHub issue reference (`#<number>`), or an ad-hoc description. When the input could plausibly be a beads ID, try `bd show <input> --json` first; if it returns an issue, treat it as one. Otherwise fall through.
 
-**If beads ID:**
+**Beads ID:**
 
 ```bash
 bd show <id> --json
@@ -29,8 +29,16 @@ If it's an epic, also fetch subtasks:
 bd list --parent <id> --json
 ```
 
-**If ad-hoc description (no beads ID):**
-Create a beads issue first:
+**GitHub issue (`#<number>`):** Fetch and convert to a beads issue:
+
+```bash
+gh issue view <number> --json title,body,labels,number
+bd create "<title>" -d "GitHub: #<number> — <description>" -t <type> -p <priority> --json
+```
+
+Map GitHub labels to beads types. Priority 1 for bugs, 2 for features/tasks.
+
+**Ad-hoc description:** Create a beads issue:
 
 ```bash
 bd create "<description>" -t <task|bug|feature> -p 2 --json
@@ -44,28 +52,9 @@ If the issue is a fix for code on an existing feature branch (e.g., CI failure o
 
 ## Branch Mode
 
-All work uses branches and PRs. Uses worktree isolation for subagents.
+You're in your worktree from `/work` — `pwd` is its path. Implementer subagents spawn with `isolation: "worktree"` (the `WorktreeCreate` hook handles branch + per-worktree project setup). Rebase, reviewer, and test-runner subagents enter your existing worktree via a `WORKTREE` field — do NOT use `isolation: "worktree"` for those.
 
-### 1. Setup
-
-**Always branch from `origin/main` unless explicitly directed otherwise by the prompt.** Fetch first to ensure it's up to date:
-
-```bash
-git fetch origin main
-git branch feature/<work-name> origin/main
-```
-
-Then enter a worktree:
-
-```
-EnterWorktree(name: "<work-name>")
-```
-
-The coordinator works from its worktree for the rest of the session.
-
-If your project requires per-worktree dependency setup (symlinks, lockfile resolution, generated files), run that here. Document the steps in CLAUDE.md so they stay in sync with project changes.
-
-### 2. Conflict Avoidance
+### 1. Conflict Avoidance
 
 Before parallelizing tasks, analyze file overlap:
 
@@ -90,7 +79,7 @@ When in doubt, add a dependency:
 bd dep add <later-task-id> <earlier-task-id> --json
 ```
 
-### 3. Implement Tasks
+### 2. Implement Tasks
 
 **Follow the dependency graph from beads.** Spawn all currently-unblocked tasks in parallel. When a task completes, check if any blocked tasks are now unblocked and spawn those.
 
@@ -172,7 +161,7 @@ Triage the "Concerns" section:
 - If blocked: note the blocker, move to next task
 - Do NOT close the task
 
-### 4. Pre-PR Review
+### 3. Pre-PR Review
 
 Reviews are **optional** for small, isolated changes (single-file fixes, typo corrections, config tweaks). For anything of any complexity — multi-file changes, new features, behavioral changes, refactors — reviews are **required**.
 
@@ -230,7 +219,7 @@ COMMANDS:
 
 **Skip the test-runner** if the epic has no acceptance tests. **Do NOT create PR if the test-runner reports FAIL.** Fix locally first (spawn implementer if non-trivial).
 
-### 5. Create PR, Monitor CI, and Hand Off
+### 4. Create PR, Monitor CI, and Hand Off
 
 Run quality gates per the **Quality Gates** table in CLAUDE.md before creating the PR. Delegate to a test-runner sub-agent so verbose output doesn't pollute the coordinator's context.
 
@@ -313,5 +302,5 @@ gh pr checks <number> --watch
 - Merging PRs (that's `/merge`'s job)
 - Handing off to `/merge` before CI passes — coordinator owns CI failures and must fix them
 - Cleaning up worktrees before merge (that's `/merge`'s job)
-- Manually creating worktrees with `git worktree add` — use `EnterWorktree` or `isolation: "worktree"`
-- Using `isolation: "worktree"` for rebase/reviewer/test-runner agents — they enter existing worktrees
+- Manually creating worktrees with `git worktree add` for subagents — use `isolation: "worktree"` so the `WorktreeCreate` hook handles setup
+- Using `isolation: "worktree"` for rebase/reviewer/test-runner agents — they enter the coordinator's existing worktree

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -19,6 +19,7 @@ This skill covers development only — no issue tracking, no pushes. The coordin
 - **Test cases from the issue are your spec.** When the planner has defined concrete test cases on the task, implement those first, then add high-value coverage for gaps.
 - **Delegate quality-gate runs to a test-runner sub-agent.** Verbose test output consumes your context window — see Phase 3.
 - **If your project enforces lint/typecheck via git hooks** (e.g., lefthook, husky), do not re-run those gates manually. Focus on tests in Phase 3 and let the hooks do their job at commit/push time.
+- **If a hook blocks a tool call, stop.** Never work around it with scripts, `sed`, or other indirect tricks. Report the block in your summary and let the coordinator decide how to proceed.
 
 ## Phase 1: Write Failing Tests
 

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -112,7 +112,13 @@ git rebase --abort
 ```
 Then output `RESULT: FAIL`.
 
-### 4. Advance target ref
+### 4. Run quality gates
+
+After a successful rebase, verify the result still passes. Pull the gate command from the **Quality Gates** table in CLAUDE.md (typically the same command the implementer ran in its Phase 3 — e.g., `npx lefthook run pre-push`, `make test`, or your project's pre-push equivalent).
+
+If it fails, the conflict resolution introduced an error. Fix it, amend the relevant commit, and re-run. If the fix is non-trivial, abort and escalate (`RESULT: FAIL`).
+
+### 5. Advance target ref
 
 ```bash
 git branch -f <target> HEAD
@@ -123,7 +129,7 @@ If `<target>` tracks a remote, also push:
 git push origin <target>
 ```
 
-### 5. Cleanup (if enabled)
+### 6. Cleanup (if enabled)
 
 ```bash
 git worktree remove <worktree> --force 2>/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .beads/
+.stale-worktree


### PR DESCRIPTION
## Summary

- Adds a deterministic stale-worktree block: `mark-stale-worktree.sh` (SessionStart) drops a marker when pwd is inside a worktree; `block-stale-worktree.sh` (PreToolUse matcher `*`) refuses every tool except `EnterWorktree`/`ExitWorktree` until the agent clears it. Replaces the text-only stale-worktree warning that coordinators frequently ignored when resuming work in a stale worktree.
- Adds `worktree-create.sh` (WorktreeCreate) so subagents spawning with `isolation: "worktree"` get a worktree branched from caller HEAD, plus a customizable post-create block consuming projects can fill in for their own per-worktree setup (node_modules symlink, generated files, etc.).
- Adds `ask-on-main-edit.sh` (PreToolUse: Edit|Write|NotebookEdit) to require user approval when a write targets the main checkout. Catches the "I'm in a worktree but used an absolute main-repo path" mistake.
- Adds `set-repo-root.sh` (SessionStart + CwdChanged) so other hooks resolve via `$REPO_ROOT/.claude/hooks/...` from any worktree.

## Why this matters

The recurring failure mode has been coordinators resuming in a stale worktree from a previous session, getting distracted by the user's request, and starting work on whatever branch they were left on — stale reads, wrong-branch edits, lost work. Strong warning text wasn't enough; deterministic enforcement is. The block message includes a fallback for the rare concurrent-legit case: "if this is NOT a fresh session and another agent is legitimately working in this worktree, pause and check in with the user before proceeding."

## Skill / command cleanups

- `commands/work.md`: drops the duplicated `## 1. Parse Input` (the `bd-*` / `#<N>` rules didn't match real beads ID formats anyway). Input parsing now lives only in the coordinator skill, with a "try `bd show` first" fuzzy disambiguation.
- `coordinator/SKILL.md`: skill's Parse Input handles all three input forms (beads ID, `#<number>` GitHub issue, ad-hoc description). Drops the manual Setup section (`/work` owns the coordinator's worktree). Updates anti-pattern about manual worktree creation to apply only to subagent worktrees.
- `implementer/SKILL.md`: adds "if a hook blocks a tool call, stop — never work around it" principle.
- `rebase/SKILL.md`: adds Phase 4 "Run quality gates" after conflict resolution, before advancing the target ref.
- `commands/bug.md`: adds **MANDATORY: Delegation to /work** section to prevent `/bug` from skipping branch/PR/review.

## Test plan

- [ ] Start a fresh session inside `.claude/worktrees/<existing>` of a consuming project — verify the first tool call gets blocked with the new message.
- [ ] From the block, call `ExitWorktree(action: "keep")` — verify subsequent tools pass through.
- [ ] From the main checkout, run `/work some-task` — verify the worktree is created and entered, no block fires.
- [ ] Spawn an implementer subagent with `isolation: "worktree"` — verify `worktree-create.sh` creates the worktree branched from caller HEAD.
- [ ] Attempt to Edit a file at an absolute path inside the main checkout from a worktree — verify the ask-on-main-edit prompt fires.